### PR TITLE
Fixing 'ReferenceError: moment is not defined' when booking a meeting.

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -2,6 +2,7 @@
 const dotenv = require("dotenv");
 const express = require("express");
 const bodyParser = require("body-parser");
+const moment = require("moment");
 
 // Enable dotenv
 dotenv.config();


### PR DESCRIPTION
This PR fixes an error I see from the Node server after I click to book a meeting with the demo.

```
/Users/joe/Work/Developer-Demo-Starter/app/server.js:128
    const meetingDate = moment(slot.start).format("DD MMM YYYY");
                        ^

ReferenceError: moment is not defined
    at /Users/joe/Work/Developer-Demo-Starter/app/server.js:128:25
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```
