### PR TITLE
Fixing 'date is too far in the past' API error

### DIFF
--- a/app/templates/availability.ejs
+++ b/app/templates/availability.ejs
@@ -25,6 +25,12 @@
 
         <script src="https://elements.cronofy.com/js/CronofyElements.v1.35.4.js"></script>
         <script>
+            const dateStart = new Date();
+            const dateEnd = new Date();
+            dateEnd.setDate(dateStart.getDate() + 14);
+            // The microsecond part of an ISO date string must be removed.
+            const dateStartString = dateStart.toISOString().replace(/\.\d+/, '');
+            const dateEndString = dateEnd.toISOString().replace(/\.\d+/, '');
 
             const dateTimePickerOptions = {
                 element_token: "<%= element_token %>",
@@ -41,8 +47,7 @@
                     ],
                     required_duration: { minutes: 60 },
                     available_periods: [
-                        { start: "2020-11-03T09:00:00Z", end: "2020-11-03T10:00:00Z" },
-                        { start: "2020-11-03T15:00:00Z", end: "2020-11-03T17:30:00Z" }
+                        { start: dateStartString, end: dateEndString }
                     ]
                 },
                 callback: res => {


### PR DESCRIPTION
This PR updates the default dates used with the availability API to avoid a 'date is too far in the past' error from the Cronofy API.

Example errors in API response:
```
{
    "errors": {
        "query_periods[0].start": [
            {
                "key": "errors.min_date_exceeded",
                "description": "date is too far in the past"
            }
        ],
        "query_periods[1].start": [
            {
                "key": "errors.min_date_exceeded",
                "description": "date is too far in the past"
            }
        ]
    }
}
```
